### PR TITLE
fix: pdf export of avatars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1881,9 +1881,9 @@
       }
     },
     "@progress/kendo-drawing": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@progress/kendo-drawing/-/kendo-drawing-1.10.0.tgz",
-      "integrity": "sha512-VfnvBQU9mnmJpu5XMQQC5qh7IGGNLGft03fplLK6unEyJaTn3u1zcw7IrnXplux7+dFKDsfzeV7fwxoFpYI/+A==",
+      "version": "1.10.1-dev.202105200720",
+      "resolved": "https://registry.npmjs.org/@progress/kendo-drawing/-/kendo-drawing-1.10.1-dev.202105200720.tgz",
+      "integrity": "sha512-DLgDkCQ0WRStfG2o2B63OyQD/vv24BGFOXY1ySFvcOpD0X/SHLb4UVjTAVDvwgsS41f+Q5CkzF6zvcSOCTkMpQ==",
       "requires": {
         "@progress/pako-esm": "^1.0.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1881,9 +1881,9 @@
       }
     },
     "@progress/kendo-drawing": {
-      "version": "1.10.1-dev.202105200720",
-      "resolved": "https://registry.npmjs.org/@progress/kendo-drawing/-/kendo-drawing-1.10.1-dev.202105200720.tgz",
-      "integrity": "sha512-DLgDkCQ0WRStfG2o2B63OyQD/vv24BGFOXY1ySFvcOpD0X/SHLb4UVjTAVDvwgsS41f+Q5CkzF6zvcSOCTkMpQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@progress/kendo-drawing/-/kendo-drawing-1.10.1.tgz",
+      "integrity": "sha512-TuGNh7r4HbmE9KB0HOyIPiaW1HBPqjbeGal3C/uqr4Lu1rQSNg1Rl+DjY5C9mKHxXl+L6T0bexLJOANxy8cTpg==",
       "requires": {
         "@progress/pako-esm": "^1.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@progress/kendo-data-query": "^1.5.4",
     "@progress/kendo-date-math": "^1.5.1",
-    "@progress/kendo-drawing": "dev",
+    "@progress/kendo-drawing": "^1.10.1",
     "@progress/kendo-licensing": "^1.1.3",
     "@progress/kendo-react-buttons": "^4.6.0",
     "@progress/kendo-react-charts": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@progress/kendo-data-query": "^1.5.4",
     "@progress/kendo-date-math": "^1.5.1",
-    "@progress/kendo-drawing": "^1.10.0",
+    "@progress/kendo-drawing": "dev",
     "@progress/kendo-licensing": "^1.1.3",
     "@progress/kendo-react-buttons": "^4.6.0",
     "@progress/kendo-react-charts": "^4.6.0",

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,14 +1,17 @@
 import React from 'react';
+import { Button } from '@progress/kendo-react-buttons';
 import { Icon } from '@progress/kendo-react-common';
 import { CircularGauge } from '@progress/kendo-react-gauges';
 import { Skeleton } from '@progress/kendo-react-indicators';
 import { Card, CardHeader, CardBody } from '@progress/kendo-react-layout';
+import { savePDF } from "@progress/kendo-react-pdf";
 import Avatar from 'avataaars';
 
 import { generateEmptyPeople, generateRandomPeople, Person } from '../data/people';
 import Render from './Render';
 
 export default function Home() {
+  const cardContainer = React.useRef<HTMLDivElement>(null);
   const [allPeople, setAllPeople] = React.useState<Person[]>(generateEmptyPeople(20));
 
   React.useEffect(() => {
@@ -17,9 +20,21 @@ export default function Home() {
     }, 2000);
   }, []);
 
+
+  const exportPDF = () => {
+    let element = cardContainer.current || document.body;
+    savePDF(element, {
+      imageResolution: 200
+    })
+  }
+
   return (
     <>
-      <div className="card-container">
+      <div className="actions">
+        <Button icon="file-pdf" onClick={exportPDF} primary={true}>Export as PDF</Button>
+      </div>
+
+      <div className="card-container" ref={cardContainer}>
         {allPeople.map((person, index) => (
           <Card key={index}>
             <Render if={person.name === ''}>


### PR DESCRIPTION
Uses `kendo-drawing` to fix the export of inline SVGs with emojis (4-byte Unicode characters).